### PR TITLE
Fix LLM Spans missing Trace ID

### DIFF
--- a/lib/langchain/datadog/tracing.rb
+++ b/lib/langchain/datadog/tracing.rb
@@ -13,8 +13,7 @@ module Langchain
 
       # Returns the active span ID.
       def self.active_span_id
-        @active_span_id ||
-          (::Datadog::Tracing.active_span&.id if defined? ::Datadog)
+        @active_span_id
       end
 
       # Returns the active parent span ID.

--- a/lib/langchain/datadog/version.rb
+++ b/lib/langchain/datadog/version.rb
@@ -2,6 +2,6 @@
 
 module Langchain
   module Datadog
-    VERSION = '0.2.1.rc1'
+    VERSION = '0.2.1'
   end
 end

--- a/lib/langchain/datadog/version.rb
+++ b/lib/langchain/datadog/version.rb
@@ -2,6 +2,6 @@
 
 module Langchain
   module Datadog
-    VERSION = '0.2.0'
+    VERSION = '0.2.1.rc1'
   end
 end


### PR DESCRIPTION
This PR fixes an issue where LLM spans were sometimes not linked to a trace in Datadog. 

The `active_span_id` method previously fell back to using the span ID from the global Datadog tracing context when the internal span ID wasn’t available. However, it seems Datadog doesn’t fully support this behavior. This fallback has been removed to ensure spans are correctly associated with their trace when available.

